### PR TITLE
indentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 requests
 os
 json
-smtplib, ssl
+smtplib 
+ssl
 imaplib
 time
 base64


### PR DESCRIPTION
 a Comma btween smtplib & ssl is causing issue on installing pip requirements 